### PR TITLE
Add mirror tile service

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -15,6 +15,9 @@ LOCAL_RESOURCE_DIR := $(LOCAL_PATH)/res
 
 LOCAL_PROGUARD_FLAG_FILES := proguard.flags
 
+LOCAL_STATIC_JAVA_LIBRARIES += \
+    androidx.annotation_annotation \
+
 ifneq ($(INCREMENTAL_BUILDS),)
     LOCAL_PROGUARD_ENABLED := disabled
     LOCAL_JACK_ENABLED := incremental

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -41,5 +41,14 @@
                 android:name="com.android.settings.summary"
                 android:value="@string/desktop_dashboard_summary" />
         </activity>
+        <service
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:icon="@drawable/ic_mirroring_disabled"
+            android:label="@string/quick_settings_mirroring_mode_label"
+            android:name="com.maru.settings.desktop.MirrorTileService">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/res/drawable/ic_mirroring_disabled.xml
+++ b/res/drawable/ic_mirroring_disabled.xml
@@ -1,0 +1,29 @@
+<!--
+    Copyright (C) 2015-2016 Preetam J. D'Souza
+    Copyright (C) 2016 The Maru OS Project
+
+    This work is licensed under the Creative Commons Attribution 4.0
+    International License (CC-BY 4.0). To view a copy of the license, visit
+
+    https://creativecommons.org/licenses/by/4.0/
+
+    Derived from Material Design icons "desktop windows" and "smartphone"
+    https://design.google.com/icons/#ic_desktop_windows
+    https://design.google.com/icons/#ic_smartphone
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="48dp"
+        android:height="48dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+        <path
+            android:name="monitor"
+            android:fillColor="#4DFFFFFF"
+            android:pathData="m3 2c-1.1 0-2 0.9-2 2v9h2v-9h18v12h-13.327v2h2.327v2h-2v2h8v-2h-2v-2h7c1.1 0 2-0.9 2-2v-12c0-1.1-0.9-2-2-2z"/>
+
+        <path
+            android:name="phone"
+            android:fillColor="#4DFFFFFF"
+            android:pathData="m2.2324 13.946c-0.4027 0-0.7324 0.33-0.7324 0.733v6.5889c0 0.402 0.3297 0.732 0.7324 0.732h3.6602c0.4027 0 0.7324-0.33 0.7324-0.732v-6.5889c0-0.40268-0.32974-0.72852-0.73242-0.72852l-3.6602-0.0039zm0 1.4639h3.6602v5.125h-3.6602v-5.125zm0.40625 0.52734v3.9863h2.8477v-3.9863h-2.8477z"/>
+</vector>

--- a/res/drawable/ic_mirroring_enabled.xml
+++ b/res/drawable/ic_mirroring_enabled.xml
@@ -1,0 +1,29 @@
+<!--
+    Copyright (C) 2015-2016 Preetam J. D'Souza
+    Copyright (C) 2016 The Maru OS Project
+
+    This work is licensed under the Creative Commons Attribution 4.0
+    International License (CC-BY 4.0). To view a copy of the license, visit
+
+    https://creativecommons.org/licenses/by/4.0/
+
+    Derived from Material Design icons "desktop windows" and "smartphone"
+    https://design.google.com/icons/#ic_desktop_windows
+    https://design.google.com/icons/#ic_smartphone
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="48dp"
+        android:height="48dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+        <path
+            android:name="monitor"
+            android:fillColor="#FFFFFFFF"
+            android:pathData="m3 2c-1.1 0-2 0.9-2 2v9h2v-9h18v12h-13.327v2h2.327v2h-2v2h8v-2h-2v-2h7c1.1 0 2-0.9 2-2v-12c0-1.1-0.9-2-2-2h-18zm1 3v8h3.6729v2h12.327v-10h-16z"/>
+
+        <path
+            android:name="phone"
+            android:fillColor="#FFFFFFFF"
+            android:pathData="m2.2324 13.946c-0.4027 0-0.7324 0.33-0.7324 0.733v6.5889c0 0.402 0.3297 0.732 0.7324 0.732h3.6602c0.4027 0 0.7324-0.33 0.7324-0.732v-6.5889c0-0.40268-0.32974-0.72852-0.73242-0.72852l-3.6602-0.0039zm0 1.4639h3.6602v5.125h-3.6602v-5.125zm0.40625 0.52734v3.9863h2.8477v-3.9863h-2.8477z"/>
+</vector>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -29,4 +29,12 @@
     <string name="desktop_shutdown_dialog_details">Your desktop apps will be closed immediately so make sure you save any unfinished work.</string>
     <string name="desktop_shutdown_dialog_negative_action">Cancel</string>
     <string name="desktop_shutdown_dialog_positive_action">Shutdown</string>
+
+    <!-- QuickSettings: MMirror [CHAR LIMIT=NONE] -->
+    <string name="quick_settings_mirroring_mode_label">Mirror screen</string>
+    <!-- Announcement made when mirroring changes to disabled (not shown on the screen). [CHAR LIMIT=NONE] -->
+    <string name="accessibility_qs_mirroring_changed_off">Screen mirroring turned off.</string>
+    <!-- Announcement made when mirroring changes to enabled (not shown on the screen). [CHAR LIMIT=NONE] -->
+    <string name="accessibility_qs_mirroring_changed_on">Screen mirroring turned on.</string>
+
 </resources>

--- a/src/com/maru/settings/desktop/MirrorTileService.java
+++ b/src/com/maru/settings/desktop/MirrorTileService.java
@@ -40,6 +40,7 @@ public class MirrorTileService extends TileService {
         mListening = true;
         mDisplayListener.sync();
         mDisplayManager.registerDisplayListener(mDisplayListener, null);
+        refreshState();
     }
 
     @Override

--- a/src/com/maru/settings/desktop/MirrorTileService.java
+++ b/src/com/maru/settings/desktop/MirrorTileService.java
@@ -1,0 +1,99 @@
+package com.maru.settings.desktop;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.drawable.Icon;
+import android.mperspective.Perspective;
+import android.mperspective.PerspectiveManager;
+import android.os.Build;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+import android.util.Log;
+import androidx.annotation.RequiresApi;
+
+import com.maru.settings.R;
+
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class MirrorTileService extends TileService {
+    private static final String TAG = "MirrorTileService";
+
+    private PerspectiveManager mPerspectiveManager;
+    private boolean mIsListening;
+
+    @Override
+    public void onTileAdded() {
+        super.onTileAdded();
+        if (mPerspectiveManager == null) {
+            mPerspectiveManager = (PerspectiveManager) getSystemService(Context.PERSPECTIVE_SERVICE);
+        }
+        mPerspectiveManager.registerPerspectiveListener(new DesktopPerspectiveListener(), null);
+    }
+
+    @Override
+    public void onStartListening() {
+        super.onStartListening();
+        mIsListening = true;
+        if (mPerspectiveManager != null) {
+            updateDesktopStateInternal(mPerspectiveManager.isDesktopRunning());
+        }
+    }
+
+    @Override
+    public void onStopListening() {
+        mIsListening = false;
+        super.onStopListening();
+    }
+
+    @Override
+    public void onTileRemoved() {
+        super.onTileRemoved();
+        if (mPerspectiveManager != null) {
+            mPerspectiveManager.unregisterPerspectiveListener();
+        }
+    }
+
+    @Override
+    public void onClick() {
+        super.onClick();
+        if (mPerspectiveManager != null) {
+            boolean isDesktopRunning = mPerspectiveManager.isDesktopRunning();
+            Log.d(TAG, "onClick current desktop running state " + isDesktopRunning);
+            if (isDesktopRunning) {
+                mPerspectiveManager.stopDesktopPerspective();
+            } else {
+                mPerspectiveManager.startDesktopPerspective();
+            }
+        }
+    }
+
+    private void updateDesktopStateInternal(boolean isMirroring) {
+        Tile tile = getQsTile();
+        if (tile == null) {
+            return;
+        }
+        Resources resources = getResources();
+        int iconId = isMirroring ? R.drawable.ic_mirroring_enabled : R.drawable.ic_mirroring_disabled;
+        tile.setIcon(Icon.createWithResource(resources, iconId));
+        int descriptionId = isMirroring ? R.string.accessibility_qs_mirroring_changed_on
+                : R.string.accessibility_qs_mirroring_changed_off;
+        tile.setContentDescription(resources.getString(descriptionId));
+        tile.setState(isMirroring ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
+        tile.updateTile();
+    }
+
+    private void updateDesktopStateIfNeeded(int state) {
+        Log.d(TAG, "updateDesktopStateIfNeeded: " + Perspective.stateToString(state)
+                + ", listening " + mIsListening);
+        if (mIsListening) {
+            getMainThreadHandler().post(() -> updateDesktopStateInternal(state == Perspective.STATE_RUNNING));
+        }
+    }
+
+    private final class DesktopPerspectiveListener implements PerspectiveManager.PerspectiveListener {
+        @Override
+        public void onPerspectiveStateChanged(int state) {
+            Log.d(TAG, "onPerspectiveStateChanged: " + Perspective.stateToString(state));
+            updateDesktopStateIfNeeded(state);
+        }
+    }
+}

--- a/src/com/maru/settings/desktop/MirrorTileService.java
+++ b/src/com/maru/settings/desktop/MirrorTileService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2016 Preetam J. D'Souza
+ * Copyright 2016-2021 The Maru OS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.maru.settings.desktop;
 
 import android.content.Context;


### PR DESCRIPTION
Adding basic mirror tile service. It is not added to the first quick panel page, and it should be added to quick panel by quick panel's editor function, if user wants to use it. I know the `maru-0.6` modified source code to add it to quick panel directly, and the new method can only implement it with normal tile, that is limited, but I think it is enough for user to use, and it can provide more convenience to maintain and develop this feature. Hi @pdsouza, looking forward your opinion about it.